### PR TITLE
Webone accordion proof of concept

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,5 +20,5 @@ MAIL_PASSWORD=null
 # uncomment to change how images are retrieved; include the trailing slash in URL
 #IMAGE_VIEW_LOCATION=http://localhost/faculty/public/uploads/imgs/
 
-CITATIONS_URL=https://api.metalab.csun.edu/citations/1.1/
+CITATIONS_URL=https://api.example.com/citations/1.0/
 GUZZLE_VERIFY_CERT=false

--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,5 @@ MAIL_PASSWORD=null
 
 # uncomment to change how images are retrieved; include the trailing slash in URL
 #IMAGE_VIEW_LOCATION=http://localhost/faculty/public/uploads/imgs/
+
+GUZZLE_VERIFY_CERT=false

--- a/.env.example
+++ b/.env.example
@@ -20,4 +20,5 @@ MAIL_PASSWORD=null
 # uncomment to change how images are retrieved; include the trailing slash in URL
 #IMAGE_VIEW_LOCATION=http://localhost/faculty/public/uploads/imgs/
 
+CITATIONS_URL=https://api.metalab.csun.edu/citations/1.1/
 GUZZLE_VERIFY_CERT=false

--- a/app/Handlers/HandlerUtilities.php
+++ b/app/Handlers/HandlerUtilities.php
@@ -39,7 +39,7 @@ class HandlerUtilities
 	 *
 	 * @example
 	 * $attributes = "key1:value1|key2:value2";
-	 * $arr = HandlerUtilities::pipedAttributesToArray($attributes);
+	 * $arr = HandlerUtilities::attributesToArray($attributes);
 	 * var_dump($arr);
 	 *
 	 * array(2) { ["key1"]=> string(6) "value1", ["key2"]=> string(6) "value2" }
@@ -78,7 +78,7 @@ class HandlerUtilities
 					{$item['header']}
 				</h2>
 				<div class=\"field field-name-field-body field-type-text-long field-label-hidden\">
-					<p>{$item['content']}</p>
+					{$item['content']}
 				</div>
 			";
 		}

--- a/app/Handlers/HandlerUtilities.php
+++ b/app/Handlers/HandlerUtilities.php
@@ -60,6 +60,51 @@ class HandlerUtilities
 	}
 
 	/**
+	 * Takes an array of associative arrays and generates the markup that then
+	 * becomes a Web-One accordion. Each sub-array needs to have both a "header"
+	 * and "content" key that represent the appropriate part of each accordion
+	 * element.
+	 *
+	 * @param array $array The array to use for generating markup
+	 * @return string
+	 */
+	public static function weboneAccordionFromArray($array) {
+		$markup = "";
+
+		// generate the main accordion element markup
+		foreach($array as $item) {
+			$markup .= "
+				<h2 class=\"field field-name-field-title-text field-type-text field-label-hidden\">
+					{$item['header']}
+				</h2>
+				<div class=\"field field-name-field-body field-type-text-long field-label-hidden\">
+					<p>{$item['content']}</p>
+				</div>
+			";
+		}
+
+		// create the JS to make the markup function as an accordion
+        $script = "
+            (function ($) {
+                Drupal.attachBehaviors($('.jewel-accordion'));
+            })(jQuery);
+        ";
+
+        $markup = "
+            <div class=\"jewel-accordion\">
+                <div id=\"accordion\">
+                    {$markup}
+                </div>
+            </div>
+            <script type=\"text/javascript\">
+                {$script}
+            </script>
+        ";
+
+		return $markup;
+	}
+
+	/**
 	 * Removes some control characters from the given string.
 	 *
 	 * @param string $string The string from which to remove characters

--- a/app/Handlers/HandlerUtilities.php
+++ b/app/Handlers/HandlerUtilities.php
@@ -83,22 +83,12 @@ class HandlerUtilities
 			";
 		}
 
-		// create the JS to make the markup function as an accordion
-        $script = "
-            (function ($) {
-                Drupal.attachBehaviors($('.jewel-accordion'));
-            })(jQuery);
-        ";
-
         $markup = "
             <div class=\"jewel-accordion\">
                 <div id=\"accordion\">
                     {$markup}
                 </div>
             </div>
-            <script type=\"text/javascript\">
-                {$script}
-            </script>
         ";
 
 		return $markup;

--- a/app/Http/Controllers/AccordionController.php
+++ b/app/Http/Controllers/AccordionController.php
@@ -39,8 +39,9 @@ class AccordionController extends Controller
 			$anchor = str_replace(' ', '', $item['header']);
 			$markup .= "
 				<h2 class=\"field field-name-field-title-text field-type-text field-label-hidden\">
-					<a name=\"{$anchor}\"></a>{$item['header']}
+					{$item['header']}
 				</h2>
+				<a name=\"{$anchor}\"></a>
 				<div class=\"field field-name-field-body field-type-text-long field-label-hidden\">
 					<p>{$item['content']}</p>
 				</div>

--- a/app/Http/Controllers/AccordionController.php
+++ b/app/Http/Controllers/AccordionController.php
@@ -49,7 +49,7 @@ class AccordionController extends Controller
 		// create the JS to make the markup function as an accordion
 		$script = "
 			(function ($) {
-				Drupal.behaviors.csunThemeLoad($('.jewel-accordion'));
+				Drupal.attachBehaviors($('.jewel-accordion'));
 			})(jQuery);
 		";
 

--- a/app/Http/Controllers/AccordionController.php
+++ b/app/Http/Controllers/AccordionController.php
@@ -36,12 +36,10 @@ class AccordionController extends Controller
 
 		// generate the main accordion element markup
 		foreach($data as $item) {
-			$anchor = str_replace(' ', '', $item['header']);
 			$markup .= "
 				<h2 class=\"field field-name-field-title-text field-type-text field-label-hidden\">
 					{$item['header']}
 				</h2>
-				<a name=\"{$anchor}\"></a>
 				<div class=\"field field-name-field-body field-type-text-long field-label-hidden\">
 					<p>{$item['content']}</p>
 				</div>

--- a/app/Http/Controllers/AccordionController.php
+++ b/app/Http/Controllers/AccordionController.php
@@ -48,7 +48,9 @@ class AccordionController extends Controller
 
 		// create the JS to make the markup function as an accordion
 		$script = "
-			Drupal.behaviors.csunThemeLoad($('.jewel-accordion'));
+			(function ($) {
+				Drupal.behaviors.csunThemeLoad($('.jewel-accordion'));
+			})(jQuery);
 		";
 
 		$markup = "

--- a/app/Http/Controllers/AccordionController.php
+++ b/app/Http/Controllers/AccordionController.php
@@ -45,7 +45,22 @@ class AccordionController extends Controller
 				</div>
 			";
 		}
-		$markup = "<div class=\"jewel-accordion\"><div id=\"accordion\">{$markup}</div></div>";
+
+		// create the JS to make the markup function as an accordion
+		$script = "
+			alert('I cannot believe it works');
+		";
+		
+		$markup = "
+			<div class=\"jewel-accordion\">
+				<div id=\"accordion\">
+					{$markup}
+				</div>
+			</div>
+			<script type=\"text/javascript\">
+				{$script}
+			</script>
+		";
 
 		// remove any control characters and send the response
 		$markup = HandlerUtilities::removeControlCharacters($markup);

--- a/app/Http/Controllers/AccordionController.php
+++ b/app/Http/Controllers/AccordionController.php
@@ -48,9 +48,9 @@ class AccordionController extends Controller
 
 		// create the JS to make the markup function as an accordion
 		$script = "
-			alert('I cannot believe it works');
+			Drupal.behaviors.csunThemeLoad($('.jewel-accordion'));
 		";
-		
+
 		$markup = "
 			<div class=\"jewel-accordion\">
 				<div id=\"accordion\">

--- a/app/Http/Controllers/AccordionController.php
+++ b/app/Http/Controllers/AccordionController.php
@@ -34,20 +34,9 @@ class AccordionController extends Controller
 			],
 		];
 
-		// generate the main accordion element markup
-		foreach($data as $item) {
-			$markup .= "
-				<h2 class=\"field field-name-field-title-text field-type-text field-label-hidden\">
-					{$item['header']}
-				</h2>
-				<div class=\"field field-name-field-body field-type-text-long field-label-hidden\">
-					<p>{$item['content']}</p>
-				</div>
-			";
-		}
-
 		// remove any control characters and send the response
 		$markup = HandlerUtilities::removeControlCharacters($markup);
-		return $this->sendWeboneAccordionResponse($markup);
+		$markup = HandlerUtilities::weboneAccordionFromArray($markup);
+		return $this->sendResponse($markup);
 	}
 }

--- a/app/Http/Controllers/AccordionController.php
+++ b/app/Http/Controllers/AccordionController.php
@@ -34,9 +34,10 @@ class AccordionController extends Controller
 			],
 		];
 
-		// remove any control characters and send the response
+		// generate the accordion, remove any control characters, and then
+		// send the response
+		$markup = HandlerUtilities::weboneAccordionFromArray($data);
 		$markup = HandlerUtilities::removeControlCharacters($markup);
-		$markup = HandlerUtilities::weboneAccordionFromArray($markup);
 		return $this->sendResponse($markup);
 	}
 }

--- a/app/Http/Controllers/AccordionController.php
+++ b/app/Http/Controllers/AccordionController.php
@@ -46,26 +46,8 @@ class AccordionController extends Controller
 			";
 		}
 
-		// create the JS to make the markup function as an accordion
-		$script = "
-			(function ($) {
-				Drupal.attachBehaviors($('.jewel-accordion'));
-			})(jQuery);
-		";
-
-		$markup = "
-			<div class=\"jewel-accordion\">
-				<div id=\"accordion\">
-					{$markup}
-				</div>
-			</div>
-			<script type=\"text/javascript\">
-				{$script}
-			</script>
-		";
-
 		// remove any control characters and send the response
 		$markup = HandlerUtilities::removeControlCharacters($markup);
-		return $this->sendResponse($markup);
+		return $this->sendWeboneAccordionResponse($markup);
 	}
 }

--- a/app/Http/Controllers/AccordionController.php
+++ b/app/Http/Controllers/AccordionController.php
@@ -45,7 +45,7 @@ class AccordionController extends Controller
 				</div>
 			";
 		}
-		$markup = "<div id=\"accordion\" class=\"jewel-accordion\">{$markup}</div>";
+		$markup = "<div class=\"jewel-accordion\"><div id=\"accordion\">{$markup}</div></div>";
 
 		// remove any control characters and send the response
 		$markup = HandlerUtilities::removeControlCharacters($markup);

--- a/app/Http/Controllers/AccordionController.php
+++ b/app/Http/Controllers/AccordionController.php
@@ -36,7 +36,9 @@ class AccordionController extends Controller
 
 		// generate the main accordion element markup
 		foreach($data as $item) {
+			$anchor = str_replace(' ', '', $item['header']);
 			$markup .= "
+				<a name=\"{$anchor}\"></a>
 				<h2 class=\"field field-name-field-title-text field-type-text field-label-hidden\">
 					{$item['header']}
 				</h2>

--- a/app/Http/Controllers/AccordionController.php
+++ b/app/Http/Controllers/AccordionController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Classes\DataHandler;
+use App\Handlers\HandlerUtilities;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Request;
+use Symfony\Component\Process\Process;
+
+class AccordionController extends Controller
+{
+	/**
+	 * Entry point for /api/accordion.
+	 *
+	 * @return Response
+	 */
+	public function showData() {
+		$markup = "";
+
+		// simulates the structure of an accordion with data
+		$data = [
+			[
+				'header' => 'Generated One',
+				'content' => 'Generated Content One',
+			],
+			[
+				'header' => 'Generated Two',
+				'content' => 'Generated Content Two',
+			],
+			[
+				'header' => 'Generated Three',
+				'content' => 'Generated Content Three',
+			],
+		];
+
+		// generate the main accordion element markup
+		foreach($data as $item) {
+			$markup .= "
+				<h2 class=\"field field-name-field-title-text field-type-text field-label-hidden\">
+					{$item['header']}
+				</h2>
+				<div class=\"field field-name-field-body field-type-text-long field-label-hidden\">
+					<p>{$item['content']}</p>
+				</div>
+			";
+		}
+		$markup = "<div id=\"accordion\" class=\"jewel-accordion\">{$markup}</div>";
+
+		// remove any control characters and send the response
+		$markup = HandlerUtilities::removeControlCharacters($markup);
+		return $this->sendResponse($markup);
+	}
+}

--- a/app/Http/Controllers/AccordionController.php
+++ b/app/Http/Controllers/AccordionController.php
@@ -38,8 +38,8 @@ class AccordionController extends Controller
 		foreach($data as $item) {
 			$anchor = str_replace(' ', '', $item['header']);
 			$markup .= "
-				<a name=\"{$anchor}\"></a>
 				<h2 class=\"field field-name-field-title-text field-type-text field-label-hidden\">
+					<a name=\"{$anchor}\"></a>
 					{$item['header']}
 				</h2>
 				<div class=\"field field-name-field-body field-type-text-long field-label-hidden\">

--- a/app/Http/Controllers/AccordionController.php
+++ b/app/Http/Controllers/AccordionController.php
@@ -39,8 +39,7 @@ class AccordionController extends Controller
 			$anchor = str_replace(' ', '', $item['header']);
 			$markup .= "
 				<h2 class=\"field field-name-field-title-text field-type-text field-label-hidden\">
-					<a name=\"{$anchor}\"></a>
-					{$item['header']}
+					<a name=\"{$anchor}\"></a>{$item['header']}
 				</h2>
 				<div class=\"field field-name-field-body field-type-text-long field-label-hidden\">
 					<p>{$item['content']}</p>

--- a/app/Http/Controllers/CitationsController.php
+++ b/app/Http/Controllers/CitationsController.php
@@ -103,6 +103,11 @@ class CitationsController extends Controller
                 Drupal.attachBehaviors($('.jewel-accordion'));
             })(jQuery);
 		</script>
+		<style type=\"text/css\">
+			.ui-accordion-header a {
+				padding: 0;
+			}
+		</style>
         ";
 
 		// remove any control characters, and then send the response

--- a/app/Http/Controllers/CitationsController.php
+++ b/app/Http/Controllers/CitationsController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Classes\DataHandler;
+use App\Handlers\HandlerUtilities;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Request;
+use Symfony\Component\Process\Process;
+
+class CitationsController extends Controller
+{
+	/**
+	 * Displays citations for faculty publications for a specific college.
+	 *
+	 * @param int $college_id The numeric ID of the college
+	 * @return Response
+	 */
+	public function showCollegeCitations($college_id) {
+		$markup = "";
+
+		// simulates the structure of an accordion with data
+		$data = [
+			[
+				'header' => 'Generated One',
+				'content' => 'Generated Content One',
+			],
+			[
+				'header' => 'Generated Two',
+				'content' => 'Generated Content Two',
+			],
+			[
+				'header' => 'Generated Three',
+				'content' => 'Generated Content Three',
+			],
+		];
+
+		// generate the accordion, remove any control characters, and then
+		// send the response
+		$markup = HandlerUtilities::weboneAccordionFromArray($data);
+		$markup = HandlerUtilities::removeControlCharacters($markup);
+		return $this->sendResponse($markup);
+	}
+}

--- a/app/Http/Controllers/CitationsController.php
+++ b/app/Http/Controllers/CitationsController.php
@@ -44,6 +44,7 @@ class CitationsController extends Controller
 				display:inline;
 				padding:0;
 				color:#000000;
+				text-decoration:underline;
 			}
 		</style>";
 

--- a/app/Http/Controllers/CitationsController.php
+++ b/app/Http/Controllers/CitationsController.php
@@ -35,7 +35,17 @@ class CitationsController extends Controller
 	public function showCollegeCitations($college_id) {
 		$url = config('webservices.citations') . "colleges/{$college_id}/citations";
 		$years = [];
-		$markup = "";
+
+		// markup begins with style overrides for inline anchor tags in the
+		// accordion headers
+		$markup = "
+		<style type=\"text/css\">
+			.ui-accordion-header a {
+				display:inline;
+				padding:0;
+				color:#000000;
+			}
+		</style>";
 
 		// make the call and resolve the response body
 		$response = $this->guzzle->get($url);
@@ -103,11 +113,6 @@ class CitationsController extends Controller
                 Drupal.attachBehaviors($('.jewel-accordion'));
             })(jQuery);
 		</script>
-		<style type=\"text/css\">
-			.ui-accordion-header a {
-				padding: 0;
-			}
-		</style>
         ";
 
 		// remove any control characters, and then send the response

--- a/app/Http/Controllers/CitationsController.php
+++ b/app/Http/Controllers/CitationsController.php
@@ -63,7 +63,7 @@ class CitationsController extends Controller
 					<p>
 						{$abstract}
 					</p>
-				"
+				";
 
 				$years[$year][] = [
 					'header' => $citation->formatted,

--- a/app/Http/Controllers/CitationsController.php
+++ b/app/Http/Controllers/CitationsController.php
@@ -83,6 +83,15 @@ class CitationsController extends Controller
 			$markup .= HandlerUtilities::weboneAccordionFromArray($data);
 		}
 
+		// create the JS to make the markup function as an accordion
+        $markup .= "
+        <script type=\"text/javascript\">
+            (function ($) {
+                Drupal.attachBehaviors($('.jewel-accordion'));
+            })(jQuery);
+		</script>
+        ";
+
 		// remove any control characters, and then send the response
 		$markup = HandlerUtilities::removeControlCharacters($markup);
 		return $this->sendResponse($markup);

--- a/app/Http/Controllers/CitationsController.php
+++ b/app/Http/Controllers/CitationsController.php
@@ -55,6 +55,19 @@ class CitationsController extends Controller
 					$citation->metadata->abstract :
 					"No abstract available");
 
+				// generate the header section (links to profiles function based
+				// on IEEE format of names currently)
+				$header = $citation->formatted;
+				foreach($citation->membership->members as $member) {
+					$name = "{$member->first_name[0]}. {$member->last_name}";
+					$profile = "
+						<a href=\"{$member->profile}\" target=\"_blank\">
+							{$name}
+						</a>
+					";
+					$header = str_replace($name, $profile, $header);
+				}
+
 				// generate the content section
 				$content = "
 					<p>
@@ -66,7 +79,7 @@ class CitationsController extends Controller
 				";
 
 				$years[$year][] = [
-					'header' => $citation->formatted,
+					'header' => $header,
 					'content' => $content,
 				];
 			}

--- a/app/Http/Controllers/CitationsController.php
+++ b/app/Http/Controllers/CitationsController.php
@@ -8,8 +8,24 @@ use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Request;
 use Symfony\Component\Process\Process;
 
+use CSUNMetaLab\Guzzle\Factories\HandlerGuzzleFactory;
+
 class CitationsController extends Controller
 {
+	/**
+	 * The HandlerGuzzle instance.
+	 *
+	 * @var HandlerGuzzle
+	 */
+	protected $guzzle;
+
+	/**
+	 * Constructs a new CitationsController instance.
+	 */
+	public function __construct() {
+		$this->guzzle = HandlerGuzzleFactory::fromDefaults();
+	}
+
 	/**
 	 * Displays citations for faculty publications for a specific college.
 	 *
@@ -17,27 +33,57 @@ class CitationsController extends Controller
 	 * @return Response
 	 */
 	public function showCollegeCitations($college_id) {
+		$url = config('webservices.citations') . "colleges/{$college_id}/citations";
+		$years = [];
 		$markup = "";
 
-		// simulates the structure of an accordion with data
-		$data = [
-			[
-				'header' => 'Generated One',
-				'content' => 'Generated Content One',
-			],
-			[
-				'header' => 'Generated Two',
-				'content' => 'Generated Content Two',
-			],
-			[
-				'header' => 'Generated Three',
-				'content' => 'Generated Content Three',
-			],
-		];
+		// make the call and resolve the response body
+		$response = $this->guzzle->get($url);
+		$body = $this->guzzle->resolveResponseBody($response, 'json');
+		$citations = $body->citations;
 
-		// generate the accordion, remove any control characters, and then
-		// send the response
-		$markup = HandlerUtilities::weboneAccordionFromArray($data);
+		// iterate over the citations and add the non-thesis instances that
+		// are already pre-formatted and published
+		foreach($citations as $citation) {
+			if($citation->type != 'thesis' && $citation->is_published == 'true'
+				&& !empty($citation->formatted)) {
+				// we want to pull the year component of the date
+				$pieces = explode('-', $citation->published->date);
+				$year = $pieces[0];
+
+				$abstract = (!empty($citation->metadata->abstract) ?
+					$citation->metadata->abstract :
+					"No abstract available");
+
+				// generate the content section
+				$content = "
+					<p>
+						<strong>Abstract:</strong>
+					</p>
+					<p>
+						{$abstract}
+					</p>
+				"
+
+				$years[$year][] = [
+					'header' => $citation->formatted,
+					'content' => $content,
+				];
+			}
+		}
+
+		// order the years array in descending order
+		krsort($years);
+
+		// generate the markup for each element
+		foreach($years as $year => $data) {
+			$markup .= "<h3>{$year}</h3>";
+
+			// generate the accordion for the year section
+			$markup .= HandlerUtilities::weboneAccordionFromArray($data);
+		}
+
+		// remove any control characters, and then send the response
 		$markup = HandlerUtilities::removeControlCharacters($markup);
 		return $this->sendResponse($markup);
 	}

--- a/app/Http/Controllers/CitationsController.php
+++ b/app/Http/Controllers/CitationsController.php
@@ -40,7 +40,7 @@ class CitationsController extends Controller
 		// accordion headers
 		$markup = "
 		<style type=\"text/css\">
-			.ui-accordion-header a {
+			.ui-accordion-icons .ui-accordion-header a {
 				display:inline;
 				padding:0;
 				color:#000000;

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -32,37 +32,6 @@ class Controller extends BaseController
     }
 
     /**
-     * Sends the markup as a Web-One accordion with matching markup and script
-     * functionality.
-     *
-     * @param string $data The initial markup for the accordion
-     * @return Response
-     */
-    protected function sendWeboneAccordionResponse($data) {
-        // create the JS to make the markup function as an accordion
-        $script = "
-            (function ($) {
-                Drupal.attachBehaviors($('.jewel-accordion'));
-            })(jQuery);
-        ";
-
-        $data = "
-            <div class=\"jewel-accordion\">
-                <div id=\"accordion\">
-                    {$data}
-                </div>
-            </div>
-            <script type=\"text/javascript\">
-                {$script}
-            </script>
-        ";
-
-        return response()
-            ->json([['data' => $data]])
-            ->setCallback('jsonp_received');
-    }
-
-    /**
      * Finds or creates a directory given the name and
      * returns true or false.
      *

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -13,8 +13,8 @@ class Controller extends BaseController
      * Parses the request type and sends the appropriate
      * Response
      *
-     * @param Collection $data the data object.
-     * @return mixed
+     * @param string $data The markup to send
+     * @return Response
      */
     protected function sendResponse($data)
     {
@@ -25,6 +25,37 @@ class Controller extends BaseController
         if (Request::get('format') === 'html') {
             return $data;
         }
+
+        return response()
+            ->json([['data' => $data]])
+            ->setCallback('jsonp_received');
+    }
+
+    /**
+     * Sends the markup as a Web-One accordion with matching markup and script
+     * functionality.
+     *
+     * @param string $data The initial markup for the accordion
+     * @return Response
+     */
+    protected function sendWeboneAccordionResponse($data) {
+        // create the JS to make the markup function as an accordion
+        $script = "
+            (function ($) {
+                Drupal.attachBehaviors($('.jewel-accordion'));
+            })(jQuery);
+        ";
+
+        $data = "
+            <div class=\"jewel-accordion\">
+                <div id=\"accordion\">
+                    {$data}
+                </div>
+            </div>
+            <script type=\"text/javascript\">
+                {$script}
+            </script>
+        ";
 
         return response()
             ->json([['data' => $data]])

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -86,6 +86,8 @@ $app->register(CSUNMetaLab\LumenProxyPass\Providers\ProxyPassServiceProvider::cl
 
 $app->configure('guzzle');
 
+$app->configure('webservices');
+
 /*
 |--------------------------------------------------------------------------
 | Load The Application Routes

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -84,6 +84,8 @@ $app->register(CSUNMetaLab\LumenForceHttps\Providers\ForceHttpsServiceProvider::
 $app->configure('proxypass');
 $app->register(CSUNMetaLab\LumenProxyPass\Providers\ProxyPassServiceProvider::class);
 
+$app->configure('guzzle');
+
 /*
 |--------------------------------------------------------------------------
 | Load The Application Routes

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "csun-metalab/lumen-proxypass": "^1.1",
         "csun-metalab/lumen-force-https": "^1.0",
         "symfony/process": "^4.0",
-        "csun-metalab/laravel-guzzle": "^1.0"
+        "csun-metalab/laravel-guzzle": "^1.0",
+        "guzzlehttp/guzzle": "~6.0"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "vlucas/phpdotenv": "~2.2",
         "csun-metalab/lumen-proxypass": "^1.1",
         "csun-metalab/lumen-force-https": "^1.0",
-        "symfony/process": "^4.0"
+        "symfony/process": "^4.0",
+        "csun-metalab/laravel-guzzle": "^1.0"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,47 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "2ef917330744b9c3678c8a85df8bb9f4",
+    "content-hash": "911e6c4fd2a9ace8b7efe181494080c7",
     "packages": [
+        {
+            "name": "csun-metalab/laravel-guzzle",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/csun-metalab/laravel-guzzle.git",
+                "reference": "701658670aefdcf2616490ecf2e99f295716336b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/csun-metalab/laravel-guzzle/zipball/701658670aefdcf2616490ecf2e99f295716336b",
+                "reference": "701658670aefdcf2616490ecf2e99f295716336b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/Guzzle/"
+                ],
+                "psr-4": {
+                    "CSUNMetaLab\\Guzzle\\": "src/Guzzle/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthew Fritz",
+                    "email": "mattf@burbankparanormal.com"
+                }
+            ],
+            "description": "Composer package for Laravel 5.0 and above that provides a consistent method of interacting with Guzzle.",
+            "time": "2018-04-20T17:34:32+00:00"
+        },
         {
             "name": "csun-metalab/lumen-force-https",
             "version": "1.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "911e6c4fd2a9ace8b7efe181494080c7",
+    "content-hash": "ecae63471307783711906a20c5a60d33",
     "packages": [
         {
             "name": "csun-metalab/laravel-guzzle",
@@ -241,6 +241,187 @@
                 "schedule"
             ],
             "time": "2017-10-12T15:59:13+00:00"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "6.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/407b0cb880ace85c9b63c5f9551db498cb2d50ba",
+                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.4",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
+                "psr/log": "^1.0"
+            },
+            "suggest": {
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2018-04-22T15:46:56+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "v1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2016-12-20T10:07:11+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "time": "2017-03-20T17:10:46+00:00"
         },
         {
             "name": "illuminate/auth",
@@ -1658,6 +1839,56 @@
                 "psr"
             ],
             "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2016-08-06T14:39:51+00:00"
         },
         {
             "name": "psr/log",

--- a/config/guzzle.php
+++ b/config/guzzle.php
@@ -1,0 +1,82 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication credentials for all default Guzzle requests
+    |--------------------------------------------------------------------------
+    |
+    | These are the authentication credentials that will be used for all
+    | default Guzzle requests. These values will only be consulted when
+    | resolving a HandlerGuzzle instance from the HandlerGuzzleFactory class.
+    | It will not affect HandlerGuzzle objects that have been instantiated
+    | directly.
+    |
+    | If either the username or password have been provided and are non-empty
+    | then the authentication credentials will be set.
+    |
+    */
+    'auth' => [
+
+        'username' => env("GUZZLE_AUTH_USERNAME", null),
+
+        'password' => env("GUZZLE_AUTH_PASSWORD", null),
+
+        // use HTTP Basic Authentication if the method has not been specified
+        'method' => env("GUZZLE_AUTH_METHOD", null),
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Base URI for all default Guzzle requests
+    |--------------------------------------------------------------------------
+    |
+    | This is the base URI that will be used for all default Guzzle requests.
+    | This value is only consulted when resolving a HandlerGuzzle instance from
+    | the HandlerGuzzleFactory class. It will not affect HandlerGuzzle objects
+    | that have been instantiated directly.
+    |
+    | Default is null.
+    |
+    */
+    'base_uri' => env("GUZZLE_BASE_URI", null),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Should Guzzle return a JSON response body as an associative array?
+    |--------------------------------------------------------------------------
+    |
+    | Should Guzzle return a JSON response body as an associative array when
+    | using the resolveResponseBody() method in HandlerGuzzle?
+    | 
+    | The default in Guzzle 5.x was to return a response body as an associative
+    | array using the json() response method. Guzzle 6.x does not have a json()
+    | response method so this can be set to true in order to maintain the
+    | original functionality.
+    |
+    | Default is false (i.e. return the JSON response as a StdClass instance).
+    |
+    */
+    'json_assoc_array' => env("GUZZLE_JSON_ASSOC_ARRAY", false),
+
+	/*
+    |--------------------------------------------------------------------------
+    | Should Guzzle verify the server certificate for HTTPS requests?
+    |--------------------------------------------------------------------------
+    |
+    | Should Guzzle verify the server certificate during HTTPS requests? This
+    | typically requires the CA cert of the server's chain to be installed on
+    | the machine performing the Guzzle request.
+    |
+    | During development, this can be set to false safely. You may also want to
+    | set this to false when using WAMP since WAMP tends to have issues with
+    | Guzzle when attempting to verify the server certificate.
+    |
+    | Default is true.
+    |
+    */
+    'verify_cert' => env("GUZZLE_VERIFY_CERT", true),
+
+];

--- a/config/webservices.php
+++ b/config/webservices.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+
+	/*
+    |--------------------------------------------------------------------------
+    | URL of the Citations Web Service
+    |--------------------------------------------------------------------------
+    |
+    | This is the URL that points to the Citations Web Service.
+    |
+    */
+	'citations' => env('CITATIONS_URL', ''),
+
+];

--- a/routes/api.php
+++ b/routes/api.php
@@ -32,3 +32,6 @@ $router->get('institutes/{institute_id}/people', 'InstituteController@showPeople
 
 // temporary route to test accordion functionality
 $router->get('accordion', 'AccordionController@showData');
+
+// college information
+$router->get('colleges/{college_id}/publications', 'CitationsController@showCollegeCitations');

--- a/routes/api.php
+++ b/routes/api.php
@@ -29,3 +29,6 @@ $router->get('centers/{center_id}/people', 'CenterController@showPeople');
 $router->get('institutes/{institute_id}/people', 'InstituteController@showPeople');
 
 // $router->get('institutes/{institute_id}/test', 'InstituteController@showPeopleTest');
+
+// temporary route to test accordion functionality
+$router->get('accordion', 'AccordionController@showData');


### PR DESCRIPTION
This will form the basis for the new non-accordion mock-up but there was some refactoring and reorganization of code that I think works well.

Also, make sure you run `composer install` since this branch has our Guzzle package.

You'll also need two `.env` values:

```
CITATIONS_URL=https://api.metalab.csun.edu/citations/1.1/
GUZZLE_VERIFY_CERT=false
```
Essentially, doing these things in multiple accordions is a bust based upon default code that runs for the accordions in Webone. The DOM is physically manipulated and moves components around incorrectly; plus, the links to the faculty profiles in the accordion headers are not clickable since the click events are prevented from going down to the `<a>` tags.